### PR TITLE
Disable ports during loading of configuration.

### DIFF
--- a/Core/Inc/miim_library.h
+++ b/Core/Inc/miim_library.h
@@ -8,7 +8,7 @@
 #ifndef INC_MIIM_LIBRARY_H_
 #define INC_MIIM_LIBRARY_H_
 
-
+void MDIO_WAIT(uint16_t tens_of_us);
 void GPIO_SET_MDIO_MODE_INPUT();
 void GPIO_SET_MDIO_MDC_MODE_INPUT();
 void GPIO_SET_MODE_NORMAL();

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -243,6 +243,8 @@ void Configuration_From_Eeprom() {
 	uint8_t PHY;
 	uint16_t Data;
 
+	Blue_Light();
+
 	// Disable all ports until the config is set (if there is at least one config value)
 	for(PHY = 2; PHY <= 7 && Commands_Total[0][0] != 0; PHY++) {
 		Data = MIIM_DRIVER_READ(PHY, 0);
@@ -250,7 +252,6 @@ void Configuration_From_Eeprom() {
 		MIIM_DRIVER_WRITE(PHY, 0, Data);
 	}
 
-	Blue_Light();
 	Write_Commands_To_IC();
 
 	// Enable all ports after the config is set (if there is at least one config value)

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -151,11 +151,24 @@ void Write_Commands_To_IC() {
 		// We are going to assume that for now, the data is sent with the smallest byte [0:7] bits first, then [8:15]
 		Data = ((uint16_t) Commands_Total[Cmd_Index][3] << 8) | (Commands_Total[Cmd_Index][2]);
 
-		for(Generic_Index = 0; Generic_Index <= 10; Generic_Index++) {
-			MIIM_DRIVER_WRITE(PHY, REG, Data);
-			HAL_Delay(1);
-		}
+		MIIM_DRIVER_WRITE(PHY, REG, Data);
+		MDIO_WAIT(1);
 	}
+
+	// Uncomment the following code to verify what was written to the MCU
+	/*
+	for(uint8_t Cmd_Index = 0; Cmd_Index < maximum_commands; Cmd_Index++) {
+		PHY = Commands_Total[Cmd_Index][0];
+		REG = Commands_Total[Cmd_Index][1];
+		if(PHY < 2 || PHY > 24 || REG < 0 || REG > 32) {
+			break;
+		}
+		// To verify what was written to the switch chip, add "dynamic printf"-type breakpoint to the following MDIO_WAIT line.
+		// "%u:%02u 0x%02x 0x%02x (%u %u)\n", PHY, REG, Data & 0xFF, (Data >> 8) & 0xFF, Data & 0xFF, (Data >> 8) & 0xFF
+		Data = MIIM_DRIVER_READ(PHY, REG);
+		MDIO_WAIT(1);
+	}
+	// */
 }
 
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -239,8 +239,27 @@ void Read_Eeprom_Data() {
 
 void Configuration_From_Eeprom() {
 	Read_Eeprom_Data();
+
+	uint8_t PHY;
+	uint16_t Data;
+
+	// Disable all ports until the config is set (if there is at least one config value)
+	for(PHY = 2; PHY <= 7 && Commands_Total[0][0] != 0; PHY++) {
+		Data = MIIM_DRIVER_READ(PHY, 0);
+		Data = Data | 0x0800;
+		MIIM_DRIVER_WRITE(PHY, 0, Data);
+	}
+
 	Blue_Light();
 	Write_Commands_To_IC();
+
+	// Enable all ports after the config is set (if there is at least one config value)
+	for(PHY = 2; PHY <= 7 && Commands_Total[0][0] != 0; PHY++) {
+		Data = MIIM_DRIVER_READ(PHY, 0);
+		Data = Data & ~0x0800;
+		MIIM_DRIVER_WRITE(PHY, 0, Data);
+	}
+
 	Green_Light();
 
 	// Reset each value in the Commands_Total array

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -67,17 +67,8 @@ uint8_t Success[] = {1};
 uint8_t Buffer_Tx[buffer_size] = {80,81,82,83};
 uint8_t Buffer_Rx[buffer_size];
 
-uint8_t Generic_Index;
-uint32_t Current_Eeprom_Addr;
-
 uint8_t Commands_Total[maximum_commands][buffer_size];
 uint8_t Commands_Current_Index = 0;
-
-uint8_t PHY;
-uint8_t REG;
-uint16_t Data;
-
-uint8_t Condition;
 
 /* USER CODE END PV */
 
@@ -131,20 +122,24 @@ uint8_t Is_Erase() {
 }
 
 void Store_Temp_Command() {
-	for(Generic_Index = 0; Generic_Index < buffer_size; Generic_Index++) {
-		Commands_Total[Commands_Current_Index][Generic_Index] = Buffer_Rx[Generic_Index];
+	for(uint8_t i = 0; i < buffer_size; i++) {
+		Commands_Total[Commands_Current_Index][i] = Buffer_Rx[i];
 	}
 
 	Commands_Current_Index++;
 }
 
 void Write_Commands_To_IC() {
+	uint8_t PHY;
+	uint8_t REG;
+	uint16_t Data;
+
 	for(uint8_t Cmd_Index = 0; Cmd_Index < maximum_commands; Cmd_Index++) {
 		PHY = Commands_Total[Cmd_Index][0];
 		REG = Commands_Total[Cmd_Index][1];
 
 		// Test to see if PHY or REG are not acceptable values
-		if(PHY < 2 || PHY > 24 || REG < 0 || REG > 32) {
+		if(PHY < 2 || PHY > 24 || REG > 32) {
 			break;
 		}
 
@@ -160,7 +155,7 @@ void Write_Commands_To_IC() {
 	for(uint8_t Cmd_Index = 0; Cmd_Index < maximum_commands; Cmd_Index++) {
 		PHY = Commands_Total[Cmd_Index][0];
 		REG = Commands_Total[Cmd_Index][1];
-		if(PHY < 2 || PHY > 24 || REG < 0 || REG > 32) {
+		if(PHY < 2 || PHY > 24 || REG > 32) {
 			break;
 		}
 		// To verify what was written to the switch chip, add "dynamic printf"-type breakpoint to the following MDIO_WAIT line.
@@ -177,14 +172,14 @@ uint8_t Save_Commands_To_Eeprom() {
 	uint32_t Data_Word;
 
 	if (HAL_FLASHEx_DATAEEPROM_Unlock() == HAL_OK) {
-		for(Generic_Index = 0; Generic_Index < maximum_commands; Generic_Index++) {
+		for(uint8_t i = 0; i < maximum_commands; i++) {
 			// Write to the EEPROM address in multiples of 4 bytes as we are writing a 32 bit word at a time
 			Current_Eeprom_Addr += 4;
 
 			Erase_Eeprom_Addr(Current_Eeprom_Addr);
 
 			// Create the 32 bit word from the 4x byte command
-			Data_Word = (((uint32_t) Commands_Total[Generic_Index][3] << 24) | ((uint32_t) Commands_Total[Generic_Index][2] << 16) | ((uint32_t) Commands_Total[Generic_Index][1] << 8) | (Commands_Total[Generic_Index][0]));
+			Data_Word = (((uint32_t) Commands_Total[i][3] << 24) | ((uint32_t) Commands_Total[i][2] << 16) | ((uint32_t) Commands_Total[i][1] << 8) | (Commands_Total[i][0]));
 
 			Write_Eeprom_Addr(Current_Eeprom_Addr, Data_Word);
 		}
@@ -220,8 +215,10 @@ void Write_Eeprom_Addr(uint32_t Eeprom_Address, uint32_t Data) {
 void Read_Eeprom_Data() {
 	uint32_t Current_Eeprom_Addr = data_eeprom_base_addr;
 	uint32_t Command;
+	uint8_t PHY;
+	uint8_t REG;
 
-	for(Generic_Index = 0; Generic_Index < maximum_commands; Generic_Index++) {
+	for(uint8_t i = 0; i < maximum_commands; i++) {
 		Current_Eeprom_Addr += 4;
 		Command = *(uint32_t *)(Current_Eeprom_Addr);
 
@@ -229,14 +226,14 @@ void Read_Eeprom_Data() {
 		REG = (uint8_t) ((Command & data_eeprom_second_byte_mask) >> 8);
 
 		// Check for invalid PHY and REG
-		if(PHY < 2 || PHY > 24 || REG < 0 || REG > 32) {
+		if(PHY < 2 || PHY > 24 || REG > 32) {
 			break;
 		}
 
-		Commands_Total[Generic_Index][0] = PHY;
-		Commands_Total[Generic_Index][1] = REG;
-		Commands_Total[Generic_Index][2] = (uint8_t) ((Command & data_eeprom_third_byte_mask) >> 16);
-		Commands_Total[Generic_Index][3] = (uint8_t) ((Command & data_eeprom_fourth_byte_mask) >> 24);
+		Commands_Total[i][0] = PHY;
+		Commands_Total[i][1] = REG;
+		Commands_Total[i][2] = (uint8_t) ((Command & data_eeprom_third_byte_mask) >> 16);
+		Commands_Total[i][3] = (uint8_t) ((Command & data_eeprom_fourth_byte_mask) >> 24);
 	}
 }
 
@@ -247,11 +244,11 @@ void Configuration_From_Eeprom() {
 	Green_Light();
 
 	// Reset each value in the Commands_Total array
-	for(Generic_Index = 0; Generic_Index < maximum_commands; Generic_Index++) {
-		Commands_Total[Generic_Index][0] = 0;
-		Commands_Total[Generic_Index][1] = 0;
-		Commands_Total[Generic_Index][2] = 0;
-		Commands_Total[Generic_Index][3] = 0;
+	for(uint8_t i = 0; i < maximum_commands; i++) {
+		Commands_Total[i][0] = 0;
+		Commands_Total[i][1] = 0;
+		Commands_Total[i][2] = 0;
+		Commands_Total[i][3] = 0;
 	}
 }
 
@@ -259,7 +256,7 @@ uint8_t Erase_Eeprom_All(void) {
 	uint32_t Current_Eeprom_Addr = data_eeprom_base_addr;
 
 	if(HAL_FLASHEx_DATAEEPROM_Unlock() == HAL_OK) {
-		for(Generic_Index = 0; Generic_Index < maximum_commands; Generic_Index++) {
+		for(uint8_t i = 0; i < maximum_commands; i++) {
 			Current_Eeprom_Addr += 4;
 
 			Erase_Eeprom_Addr(Current_Eeprom_Addr);
@@ -365,7 +362,7 @@ int main(void)
 		  Red_Light();
 		  Write_Commands_To_IC();
 		  Green_Light();
-		  Condition = Save_Commands_To_Eeprom();
+		  uint8_t Condition = Save_Commands_To_Eeprom();
 		  if(Condition == 0) {
 			  // Success
 			  Send_Success_Via_Uart();
@@ -489,7 +486,7 @@ static void MX_DMA_Init(void)
   */
 static void MX_GPIO_Init(void)
 {
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
+  GPIO_InitTypeDef GPIO_InitStruct = {0, GPIO_MODE_OUTPUT_PP, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW, 0};
 
   /* GPIO Ports Clock Enable */
   __HAL_RCC_GPIOC_CLK_ENABLE();
@@ -503,16 +500,18 @@ static void MX_GPIO_Init(void)
 
   /*Configure GPIO pin : LED_BLUE_Pin */
   GPIO_InitStruct.Pin = LED_BLUE_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+  //GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  //GPIO_InitStruct.Pull = GPIO_NOPULL;
+  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(LED_BLUE_GPIO_Port, &GPIO_InitStruct);
 
   /*Configure GPIO pins : LED_RED_Pin MIIM_MDC_Pin LED_GREEN_Pin MIIM_MDIO_Pin */
   GPIO_InitStruct.Pin = LED_RED_Pin|MIIM_MDC_Pin|LED_GREEN_Pin|MIIM_MDIO_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+  //GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  //GPIO_InitStruct.Pull = GPIO_NOPULL;
+  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
 }

--- a/Core/Src/miim_library.c
+++ b/Core/Src/miim_library.c
@@ -9,6 +9,7 @@
 #include "main.h"
 
 volatile uint16_t us_timer = 0;
+GPIO_InitTypeDef GPIO_InitStruct = {0, 0, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW, 0};
 
 // Allow shorter than 1 ms sleeps; this function takes an argument that represents tens of microseconds.
 // The wait time isn't exact, but it should be around 5-15 us * tens_of_us
@@ -21,8 +22,6 @@ void MDIO_WAIT(uint16_t tens_of_us)
 void GPIO_SET_MDIO_MODE_INPUT() {
 	// Set MIDO pin to it's default status with HAL_GPIO_DeInit
 	HAL_GPIO_DeInit(MIIM_MDIO_GPIO_Port, MIIM_MDIO_Pin);
-
-	GPIO_InitTypeDef GPIO_InitStruct = {0};
 
 	/* GPIO Ports Clock Enable */
 	__HAL_RCC_GPIOC_CLK_ENABLE();
@@ -37,23 +36,25 @@ void GPIO_SET_MDIO_MODE_INPUT() {
 	  /*Configure GPIO pin : LED_BLUE_Pin */
 	  GPIO_InitStruct.Pin = LED_BLUE_Pin;
 	  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-	  GPIO_InitStruct.Pull = GPIO_NOPULL;
-	  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
+	  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	  HAL_GPIO_Init(LED_BLUE_GPIO_Port, &GPIO_InitStruct);
 
 	  /*Configure GPIO pins : LED_RED_Pin MIIM_MDC_Pin LED_GREEN_Pin */
 	  GPIO_InitStruct.Pin = LED_RED_Pin|MIIM_MDC_Pin|LED_GREEN_Pin;
-	  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-	  GPIO_InitStruct.Pull = GPIO_NOPULL;
-	  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+	  //GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
+	  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
 	  /*Configure GPIO pin : MIIM_MDIO_Pin */
 	  GPIO_InitStruct.Pin = MIIM_MDIO_Pin;
 	  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-	  GPIO_InitStruct.Pull = GPIO_NOPULL;
+	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
 	  HAL_GPIO_Init(MIIM_MDIO_GPIO_Port, &GPIO_InitStruct);
-
 }
 
 void GPIO_SET_MDIO_MDC_MODE_INPUT() {
@@ -78,33 +79,35 @@ void GPIO_SET_MDIO_MDC_MODE_INPUT() {
 	  /*Configure GPIO pin : LED_BLUE_Pin */
 	  GPIO_InitStruct.Pin = LED_BLUE_Pin;
 	  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-	  GPIO_InitStruct.Pull = GPIO_NOPULL;
-	  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
+	  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	  HAL_GPIO_Init(LED_BLUE_GPIO_Port, &GPIO_InitStruct);
 
 	  /*Configure GPIO pins : LED_RED_Pin MIIM_MDC_Pin LED_GREEN_Pin */
 	  GPIO_InitStruct.Pin = LED_RED_Pin|LED_GREEN_Pin;
 	  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-	  GPIO_InitStruct.Pull = GPIO_NOPULL;
-	  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
+	  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
 	  /*Configure GPIO pin : MIIM_MDIO_Pin */
 	  GPIO_InitStruct.Pin = MIIM_MDIO_Pin;
 	  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-	  GPIO_InitStruct.Pull = GPIO_NOPULL;
+	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
 	  HAL_GPIO_Init(MIIM_MDIO_GPIO_Port, &GPIO_InitStruct);
 
 	  /*Configure GPIO pin : MIIM_MDC_Pin */
 	  GPIO_InitStruct.Pin = MIIM_MDC_Pin;
-	  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-	  GPIO_InitStruct.Pull = GPIO_NOPULL;
+	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
+	  //GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
 	  HAL_GPIO_Init(MIIM_MDC_GPIO_Port, &GPIO_InitStruct);
 }
 
 void GPIO_SET_MODE_NORMAL() {
-	GPIO_InitTypeDef GPIO_InitStruct = {0};
-
 	/* GPIO Ports Clock Enable */
 	__HAL_RCC_GPIOC_CLK_ENABLE();
 	__HAL_RCC_GPIOA_CLK_ENABLE();
@@ -118,15 +121,17 @@ void GPIO_SET_MODE_NORMAL() {
 	/*Configure GPIO pin : LED_BLUE_Pin */
 	GPIO_InitStruct.Pin = LED_BLUE_Pin;
 	GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-	GPIO_InitStruct.Pull = GPIO_NOPULL;
-	GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+	// Commented out to shrink program size and fit into the flash memory; these values are already set.
+	//GPIO_InitStruct.Pull = GPIO_NOPULL;
+	//GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	HAL_GPIO_Init(LED_BLUE_GPIO_Port, &GPIO_InitStruct);
 
 	/*Configure GPIO pins : LED_RED_Pin MIIM_MDC_Pin LED_GREEN_Pin MIIM_MDIO_Pin */
 	GPIO_InitStruct.Pin = LED_RED_Pin|MIIM_MDC_Pin|LED_GREEN_Pin|MIIM_MDIO_Pin;
-	GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-	GPIO_InitStruct.Pull = GPIO_NOPULL;
-	GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+	// Commented out to shrink program size and fit into the flash memory; these values are already set.
+	//GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+	//GPIO_InitStruct.Pull = GPIO_NOPULL;
+	//GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 }
 
@@ -142,7 +147,7 @@ void _MIIM_DRIVER_START() {
 	// Preamble
 	HAL_GPIO_WritePin(GPIOA, MIIM_MDIO_Pin, GPIO_PIN_SET);
 
-	for (uint8_t i=0; i<32; ++i) {
+	for (uint8_t bitnum = 0; bitnum < 32; ++bitnum) {
 		_MIIM_DRIVER_CLOCK_PULSE();
 	}
 
@@ -207,11 +212,7 @@ void _MIIM_DRIVER_TA_READ() {
 
 void _MIIM_DRIVER_WRITE_DATA(uint16_t data) {
 	for (uint8_t bitnum = 0; bitnum <= 15; ++bitnum) {
-		if ((data & (1<<(15-bitnum))) == 0) {
-			HAL_GPIO_WritePin(GPIOA, MIIM_MDIO_Pin, GPIO_PIN_RESET);
-		} else {
-			HAL_GPIO_WritePin(GPIOA, MIIM_MDIO_Pin, GPIO_PIN_SET);
-		}
+		HAL_GPIO_WritePin(GPIOA, MIIM_MDIO_Pin, (data & (1<<(15-bitnum))) == 0 ? GPIO_PIN_RESET : GPIO_PIN_SET);
 		_MIIM_DRIVER_CLOCK_PULSE();
 	}
 	// final clock pulse afterwards

--- a/Core/Src/miim_library.c
+++ b/Core/Src/miim_library.c
@@ -28,23 +28,12 @@ void GPIO_SET_MDIO_MODE_INPUT() {
  	__HAL_RCC_GPIOA_CLK_ENABLE();
 
 	  /*Configure GPIO pin Output Level */
-	  HAL_GPIO_WritePin(LED_BLUE_GPIO_Port, LED_BLUE_Pin, GPIO_PIN_RESET);
+	  HAL_GPIO_WritePin(GPIOA, MIIM_MDC_Pin, GPIO_PIN_RESET);
 
-	  /*Configure GPIO pin Output Level */
-	  HAL_GPIO_WritePin(GPIOA, LED_RED_Pin|MIIM_MDC_Pin|LED_GREEN_Pin, GPIO_PIN_RESET);
-
-	  /*Configure GPIO pin : LED_BLUE_Pin */
-	  GPIO_InitStruct.Pin = LED_BLUE_Pin;
+	  /*Configure GPIO pin : MIIM_MDC_Pin */
+	  GPIO_InitStruct.Pin = MIIM_MDC_Pin;
 	  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
 	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
-	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
-	  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-	  HAL_GPIO_Init(LED_BLUE_GPIO_Port, &GPIO_InitStruct);
-
-	  /*Configure GPIO pins : LED_RED_Pin MIIM_MDC_Pin LED_GREEN_Pin */
-	  GPIO_InitStruct.Pin = LED_RED_Pin|MIIM_MDC_Pin|LED_GREEN_Pin;
-	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
-	  //GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
 	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
 	  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
@@ -64,33 +53,9 @@ void GPIO_SET_MDIO_MDC_MODE_INPUT() {
 	// Set MDC pin to its default status with HAL_GPIO_Deinit
 	HAL_GPIO_DeInit(MIIM_MDC_GPIO_Port, MIIM_MDC_Pin);
 
-	GPIO_InitTypeDef GPIO_InitStruct = {0};
-
 	/* GPIO Ports Clock Enable */
 	__HAL_RCC_GPIOC_CLK_ENABLE();
  	__HAL_RCC_GPIOA_CLK_ENABLE();
-
-	  /*Configure GPIO pin Output Level */
-	  HAL_GPIO_WritePin(LED_BLUE_GPIO_Port, LED_BLUE_Pin, GPIO_PIN_RESET);
-
-	  /*Configure GPIO pin Output Level */
-	  HAL_GPIO_WritePin(GPIOA, LED_RED_Pin|LED_GREEN_Pin, GPIO_PIN_RESET);
-
-	  /*Configure GPIO pin : LED_BLUE_Pin */
-	  GPIO_InitStruct.Pin = LED_BLUE_Pin;
-	  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
-	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
-	  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-	  HAL_GPIO_Init(LED_BLUE_GPIO_Port, &GPIO_InitStruct);
-
-	  /*Configure GPIO pins : LED_RED_Pin MIIM_MDC_Pin LED_GREEN_Pin */
-	  GPIO_InitStruct.Pin = LED_RED_Pin|LED_GREEN_Pin;
-	  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-	  // Commented out to shrink program size and fit into the flash memory; these values are already set.
-	  //GPIO_InitStruct.Pull = GPIO_NOPULL;
-	  //GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-	  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
 	  /*Configure GPIO pin : MIIM_MDIO_Pin */
 	  GPIO_InitStruct.Pin = MIIM_MDIO_Pin;
@@ -113,23 +78,12 @@ void GPIO_SET_MODE_NORMAL() {
 	__HAL_RCC_GPIOA_CLK_ENABLE();
 
 	/*Configure GPIO pin Output Level */
-	HAL_GPIO_WritePin(LED_BLUE_GPIO_Port, LED_BLUE_Pin, GPIO_PIN_RESET);
+	HAL_GPIO_WritePin(GPIOA, MIIM_MDC_Pin|MIIM_MDIO_Pin, GPIO_PIN_RESET);
 
-	/*Configure GPIO pin Output Level */
-	HAL_GPIO_WritePin(GPIOA, LED_RED_Pin|MIIM_MDC_Pin|LED_GREEN_Pin|MIIM_MDIO_Pin, GPIO_PIN_RESET);
-
-	/*Configure GPIO pin : LED_BLUE_Pin */
-	GPIO_InitStruct.Pin = LED_BLUE_Pin;
+	/*Configure GPIO pins : MIIM_MDC_Pin MIIM_MDIO_Pin */
+	GPIO_InitStruct.Pin = MIIM_MDC_Pin|MIIM_MDIO_Pin;
 	GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
 	// Commented out to shrink program size and fit into the flash memory; these values are already set.
-	//GPIO_InitStruct.Pull = GPIO_NOPULL;
-	//GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-	HAL_GPIO_Init(LED_BLUE_GPIO_Port, &GPIO_InitStruct);
-
-	/*Configure GPIO pins : LED_RED_Pin MIIM_MDC_Pin LED_GREEN_Pin MIIM_MDIO_Pin */
-	GPIO_InitStruct.Pin = LED_RED_Pin|MIIM_MDC_Pin|LED_GREEN_Pin|MIIM_MDIO_Pin;
-	// Commented out to shrink program size and fit into the flash memory; these values are already set.
-	//GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
 	//GPIO_InitStruct.Pull = GPIO_NOPULL;
 	//GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);


### PR DESCRIPTION
This should prevent the switch from running in a half-configured state.